### PR TITLE
Remove output check for ExampleTxn_Mutate_list.

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -692,8 +692,9 @@ func ExampleTxn_Mutate_list() {
 		log.Fatal(err)
 	}
 
+	// List items aren't guaranteed to be in the same order.
 	fmt.Println(string(resp.Json))
-	// Output: {"me":[{"address":["Riley Street","Redfern"],"phone_number":[9876,123]}]}
+	// {"me":[{"address":["Riley Street","Redfern"],"phone_number":[9876,123]}]}
 
 }
 


### PR DESCRIPTION
Why is this change necessary?

This test was failing:

    --- FAIL: ExampleTxn_Mutate_list (0.01s)
    got:
    {"me":[{"address":["Riley Street","Redfern"],"phone_number":[123,9876]}]}
    want:
    {"me":[{"address":["Riley Street","Redfern"],"phone_number":[9876,123]}]}

List types are unordered sets and the particular order of the values
is non-deterministic, so the result of the test is OK.

How does it address the issue?

The output check is skipped by removing the "Output: " prefix in the comment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgo/13)
<!-- Reviewable:end -->
