### PR TITLE
Update example_set_object_test.go

### DIFF
--- a/example_set_object_test.go
+++ b/example_set_object_test.go
@@ -37,7 +37,7 @@ type Person struct {
 }
 
 func Example_setObject() {
-	conn, err := grpc.Dial("127.0.0.1:9180", grpc.WithInsecure())
+	conn, err := grpc.Dial("127.0.0.1:9080", grpc.WithInsecure())
 	if err != nil {
 		log.Fatal("While trying to dial gRPC")
 	}


### PR DESCRIPTION
Correcting port binding on GoDoc example to reflect the port used in Getting Started page which is 9080 instead of 9081

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgo/37)
<!-- Reviewable:end -->
