### PR TITLE
readme: add missing "go" marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ fmt.Println(string(resp.Json))
 
 When running a schema query, the schema response is found in the `Schema` field of `api.Response`.
 
-```
+```go
 q := `schema(pred: [name]) {
   type
   index


### PR DESCRIPTION
This enables proper syntax highlighting on GitHub.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgo/41)
<!-- Reviewable:end -->
