### PR TITLE
dgo: fix type loc to location.

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -702,7 +702,7 @@ func ExampleDeleteEdges() {
 		me(func: uid($alice)) {
 			name
 			age
-			loc
+			location
 			married
 			friends {
 				name
@@ -721,7 +721,7 @@ func ExampleDeleteEdges() {
 
 	// Now lets delete the friend and location edge from Alice
 	mu = &api.Mutation{}
-	dgo.DeleteEdges(mu, alice, "friends", "loc")
+	dgo.DeleteEdges(mu, alice, "friends", "location")
 
 	mu.CommitNow = true
 	_, err = dg.NewTxn().Mutate(ctx, mu)


### PR DESCRIPTION
there is a mistake, no `loc` field defined here.

https://github.com/dgraph-io/dgo/blob/b04c2c20fb1fbb173d12b5b30034c9c8c647530e/examples_test.go#L724

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgo/54)
<!-- Reviewable:end -->
