### PR TITLE
Set explicit Uid field for JSON mutation in example test.

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -590,6 +590,7 @@ func ExampleTxn_Mutate_list() {
 	}
 
 	p := Person{
+		Uid:         "_:person",
 		Address:     []string{"Redfern", "Riley Street"},
 		PhoneNumber: []int64{9876, 123},
 	}
@@ -618,7 +619,7 @@ func ExampleTxn_Mutate_list() {
 		log.Fatal(err)
 	}
 
-	variables := map[string]string{"$id": assigned.Uids["blank-0"]}
+	variables := map[string]string{"$id": assigned.Uids["person"]}
 	const q = `
 	query Me($id: string){
 		me(func: uid($id)) {


### PR DESCRIPTION
This fixes an example that used the auto-generated blank node name `"blank-0"`. Auto-generated blank node names have changed with https://github.com/dgraph-io/dgraph/pull/3795. The test now sets its own blank node name and uses that instead of relying on Dgraph's auto-generated blank node name in the mutation response.

Note: This example isn't configured to run as a Go test because `// Output:` is intentionally omitted for this example. As indicated in the comment above the last line, the output is considered unordered for list schema types. This could be made as a runnable test by printing out the individual edge values and using the `Unordered output:` ([Go docs](https://golang.org/pkg/testing/#hdr-Examples)) check instead of the raw JSON response.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgo/85)
<!-- Reviewable:end -->
