### PR TITLE
Include context argument of Discard and Commit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,9 +97,9 @@ err := dgraphClient.Alter(ctx, op)
 To create a transaction, call `dgraphClient.NewTxn()`, which returns a `*dgo.Txn` object. This
 operation incurs no network overhead.
 
-It is a good practice to call `txn.Discard()` using a `defer` statement after it is initialized.
-Calling `txn.Discard()` after `txn.Commit()` is a no-op and you can call `txn.Discard()` multiple
-times with no additional side-effects.
+It is a good practice to call `txn.Discard(ctx)` using a `defer` statement after it is initialized.
+Calling `txn.Discard(ctx)` after `txn.Commit(ctx)` is a no-op. Furthermore, `txn.Discard(ctx)`
+can be called multiple times with no additional side-effects.
 
 ```go
 txn := dgraphClient.NewTxn()


### PR DESCRIPTION
Some small updates on the docs that I felt would be useful to have.
Adding `ctx` as an argument both for `txn.Discard(ctx)` and `txn.Commit(ctx)`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgo/123)
<!-- Reviewable:end -->
