### PR TITLE
fix(tests): dont use dgraph binary in tests

### DIFF
--- a/acl_test.go
+++ b/acl_test.go
@@ -19,7 +19,6 @@ package dgo_test
 import (
 	"context"
 	"fmt"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -40,6 +39,7 @@ var (
 	devgroup      = "dev"
 
 	dgraphAddress = "127.0.0.1:9180"
+	adminUrl      = "http://127.0.0.1:8180/admin"
 )
 
 func initializeDBACLs(t *testing.T, dg *dgo.Dgraph) {
@@ -61,45 +61,122 @@ func initializeDBACLs(t *testing.T, dg *dgo.Dgraph) {
 	require.NoError(t, err, "unable to insert data for read predicate")
 }
 
-func resetUser(t *testing.T) {
-	createuser := exec.Command("dgraph", "acl", "add", "-a", dgraphAddress, "-u", username, "-p",
-		userpassword, "-x", grootpassword)
+func resetUser(t *testing.T, token *HttpToken) {
+	resetUser := `mutation addUser($name: String!, $pass: String!) {
+					  addUser(input: [{name: $name, password: $pass}]) {
+						user {
+						  name
+						}
+					  }
+					}`
 
-	_, err := createuser.CombinedOutput()
-	require.NoError(t, err, "unable to create user")
+	params := &GraphQLParams{
+		Query: resetUser,
+		Variables: map[string]interface{}{
+			"name": username,
+			"pass": userpassword,
+		},
+	}
+	resp := MakeGQLRequest(t, adminUrl, params, token)
+	require.True(t, len(resp.Errors) == 0, resp.Errors)
 }
 
-func createGroupACLs(t *testing.T, groupname string) {
+func createGroupACLs(t *testing.T, groupname string, token *HttpToken) {
 	// create group
-	createGroup := exec.Command("dgraph", "acl", "add", "-a", dgraphAddress,
-		"-g", groupname, "-x", grootpassword)
-	_, err := createGroup.CombinedOutput()
-	require.NoError(t, err, "unable to create group: %s", groupname)
+	createGroup := `mutation addGroup($name: String!){
+			addGroup(input: [{name: $name}]) {
+				group {
+				  name
+				  users {
+					name
+				  }
+				}
+			  }
+			}`
+	params := &GraphQLParams{
+		Query: createGroup,
+		Variables: map[string]interface{}{
+			"name": groupname,
+		},
+	}
+	resp := MakeGQLRequest(t, adminUrl, params, token)
+	require.Truef(t, len(resp.Errors) == 0, "unable to create group: %+v", resp.Errors.Error())
+
+	// Set permissions.
+	updatePerms := `mutation updateGroup($gname: String!, $pred: String!, $perm: Int!) {
+		  updateGroup(input: {filter: {name: {eq: $gname}}, set: {rules: [{predicate: $pred, permission: $perm}]}}) {
+			group {
+			  name
+			  rules {
+				permission
+				predicate
+			  }
+			}
+		  }
+		}`
+
+	setPermission := func(pred string, permission int) {
+		params = &GraphQLParams{
+			Query: updatePerms,
+			Variables: map[string]interface{}{
+				"gname": groupname,
+				"pred":  pred,
+				"perm":  permission,
+			},
+		}
+		resp = MakeGQLRequest(t, adminUrl, params, token)
+		require.Truef(t, len(resp.Errors) == 0, "unable to set permissions: %+v", resp.Errors)
+	}
 
 	// assign read access to read predicate
-	readAccess := exec.Command("dgraph", "acl", "mod", "-a", dgraphAddress, "-g", groupname, "-p",
-		readpred, "-m", "4", "-x", grootpassword)
-	_, err = readAccess.CombinedOutput()
-	require.NoError(t, err, "unable to grant read access to group: %s", groupname)
-
+	setPermission(readpred, 4)
 	// assign write access to write predicate
-	writeAccess := exec.Command("dgraph", "acl", "mod", "-a", dgraphAddress, "-g", groupname, "-p",
-		writepred, "-m", "2", "-x", grootpassword)
-	_, err = writeAccess.CombinedOutput()
-	require.NoError(t, err, "unable to grant write access to group: %s", groupname)
-
+	setPermission(writepred, 2)
 	// assign modify access to modify predicate
-	modifyAccess := exec.Command("dgraph", "acl", "mod", "-a", dgraphAddress, "-g", groupname, "-p",
-		modifypred, "-m", "1", "-x", grootpassword)
-	_, err = modifyAccess.CombinedOutput()
-	require.NoError(t, err, "unable to grant modify access to group: %s", groupname)
+	setPermission(modifypred, 1)
 }
 
-func addUserToGroup(t *testing.T, username, groupname string) {
-	linkCmd := exec.Command("dgraph", "acl", "mod", "-a", dgraphAddress, "-u", username,
-		"--group_list", groupname, "-x", grootpassword)
-	_, err := linkCmd.CombinedOutput()
-	require.NoError(t, err, "unable to link user: %s and group: %s", username, groupname)
+func addUserToGroup(t *testing.T, username, group, op string, token *HttpToken) {
+	addToGroup := `mutation updateUser($name: String, $group: String!) {
+		updateUser(input: {filter: {name: {eq: $name}}, set: {groups: [{name: $group}]}}) {
+			user {
+			  name
+			  groups {
+				name
+			}
+			}
+		  }
+		}`
+	removeFromGroup := `mutation updateUser($name: String, $group: String!) {
+		updateUser(input: {filter: {name: {eq: $name}}, remove: {groups: [{name: $group}]}}) {
+			user {
+			  name
+			  groups {
+				name
+			}
+			}
+		  }
+		}`
+
+	var query string
+	switch op {
+	case "add":
+		query = addToGroup
+	case "del":
+		query = removeFromGroup
+	default:
+		require.Fail(t, "invalid operation for updating user")
+	}
+
+	params := &GraphQLParams{
+		Query: query,
+		Variables: map[string]interface{}{
+			"name":  username,
+			"group": group,
+		},
+	}
+	resp := MakeGQLRequest(t, adminUrl, params, token)
+	require.Truef(t, len(resp.Errors) == 0, "unable to update user: %+v", resp.Errors)
 }
 
 func query(t *testing.T, dg *dgo.Dgraph, shouldFail bool) {
@@ -150,33 +227,39 @@ func TestACLs(t *testing.T) {
 
 	initializeDBACLs(t, dg)
 
-	resetUser(t)
+	token, err := HttpLogin(&LoginParams{
+		Endpoint:  adminUrl,
+		UserID:    "groot",
+		Passwd:    "password",
+		Namespace: 0, // Galaxy namespace
+	})
+	resetUser(t, token)
 	time.Sleep(5 * time.Second)
 
 	// All operations without ACLs should fail.
-	err := dg.Login(context.Background(), username, userpassword)
+	err = dg.Login(context.Background(), username, userpassword)
 	require.NoError(t, err, "unable to login for user: %s", username)
 	query(t, dg, true)
 	mutation(t, dg, true)
 	changeSchema(t, dg, true)
 
 	// Create unused group, everything should still fail.
-	createGroupACLs(t, unusedgroup)
+	createGroupACLs(t, unusedgroup, token)
 	time.Sleep(6 * time.Second)
 	query(t, dg, true)
 	mutation(t, dg, true)
 	changeSchema(t, dg, true)
 
 	// Create dev group and link user to it. Everything should pass now.
-	createGroupACLs(t, devgroup)
-	addUserToGroup(t, username, devgroup)
+	createGroupACLs(t, devgroup, token)
+	addUserToGroup(t, username, devgroup, "add", token)
 	time.Sleep(6 * time.Second)
 	query(t, dg, false)
 	mutation(t, dg, false)
 	changeSchema(t, dg, false)
 
 	// Remove user from dev group, everything should fail now.
-	addUserToGroup(t, username, "")
+	addUserToGroup(t, username, devgroup, "del", token)
 	time.Sleep(6 * time.Second)
 	query(t, dg, true)
 	mutation(t, dg, true)

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -115,7 +115,7 @@ func (gqlErr *GqlError) Error() string {
 }
 func MakeGQLRequest(t *testing.T, endpoint string, params *GraphQLParams,
 	token *HttpToken) *GraphQLResponse {
-	resp := MakeGQLRequestHelper(t, params, token)
+	resp := MakeGQLRequestHelper(t, endpoint, params, token)
 	if len(resp.Errors) == 0 || !strings.Contains(resp.Errors.Error(), "Token is expired") {
 		return resp
 	}

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -1,0 +1,230 @@
+/*
+ * Copyright (C) 2021 Dgraph Labs, Inc. and Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dgo_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dgraph-io/dgo/v200/protos/api"
+)
+
+// LoginParams stores the information needed to perform a login request.
+type LoginParams struct {
+	Endpoint   string
+	UserID     string
+	Passwd     string
+	Namespace  uint64
+	RefreshJwt string
+}
+
+type GraphQLParams struct {
+	Query     string                 `json:"query"`
+	Variables map[string]interface{} `json:"variables"`
+}
+
+type HttpToken struct {
+	UserId       string
+	Password     string
+	AccessJwt    string
+	RefreshToken string
+}
+
+type GraphQLResponse struct {
+	Data       json.RawMessage        `json:"data,omitempty"`
+	Errors     GqlErrorList           `json:"errors,omitempty"`
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}
+
+type GqlErrorList []*GqlError
+
+type GqlError struct {
+	Message    string                 `json:"message"`
+	Path       []interface{}          `json:"path,omitempty"`
+	Extensions map[string]interface{} `json:"extensions,omitempty"`
+}
+
+func MakeGQLRequestHelper(t *testing.T, endpoint string, params *GraphQLParams,
+	token *HttpToken) *GraphQLResponse {
+
+	b, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(b))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	if token.AccessJwt != "" {
+		req.Header.Set("X-Dgraph-AccessToken", token.AccessJwt)
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+	b, err = ioutil.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	var gqlResp GraphQLResponse
+	err = json.Unmarshal(b, &gqlResp)
+	require.NoError(t, err)
+
+	return &gqlResp
+}
+
+func (errList GqlErrorList) Error() string {
+	var buf bytes.Buffer
+	for i, gqlErr := range errList {
+		if i > 0 {
+			buf.WriteByte('\n')
+		}
+		buf.WriteString(gqlErr.Error())
+	}
+	return buf.String()
+}
+
+func (gqlErr *GqlError) Error() string {
+	var buf bytes.Buffer
+	if gqlErr == nil {
+		return ""
+	}
+
+	buf.WriteString(gqlErr.Message)
+	return buf.String()
+}
+func MakeGQLRequest(t *testing.T, endpoint string, params *GraphQLParams,
+	token *HttpToken) *GraphQLResponse {
+	resp := MakeGQLRequestHelper(t, params, token)
+	if len(resp.Errors) == 0 || !strings.Contains(resp.Errors.Error(), "Token is expired") {
+		return resp
+	}
+	var err error
+	token, err = HttpLogin(&LoginParams{
+		Endpoint:   endpoint,
+		UserID:     token.UserId,
+		Passwd:     token.Password,
+		RefreshJwt: token.RefreshToken,
+	})
+	require.NoError(t, err)
+	return MakeGQLRequestHelper(t, endpoint, params, token)
+}
+
+// HttpLogin sends a HTTP request to the server
+// and returns the access JWT and refresh JWT extracted from
+// the HTTP response
+func HttpLogin(params *LoginParams) (*HttpToken, error) {
+	loginPayload := api.LoginRequest{}
+	if len(params.RefreshJwt) > 0 {
+		loginPayload.RefreshToken = params.RefreshJwt
+	} else {
+		loginPayload.Userid = params.UserID
+		loginPayload.Password = params.Passwd
+	}
+
+	login := `mutation login($userId: String, $password: String, $namespace: Int, $refreshToken: String) {
+		login(userId: $userId, password: $password, namespace: $namespace, refreshToken: $refreshToken) {
+			response {
+				accessJWT
+				refreshJWT
+			}
+		}
+	}`
+
+	gqlParams := GraphQLParams{
+		Query: login,
+		Variables: map[string]interface{}{
+			"userId":       params.UserID,
+			"password":     params.Passwd,
+			"namespace":    params.Namespace,
+			"refreshToken": params.RefreshJwt,
+		},
+	}
+	body, err := json.Marshal(gqlParams)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to marshal body")
+	}
+
+	req, err := http.NewRequest("POST", params.Endpoint, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to create request")
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, errors.Wrapf(err, "login through curl failed")
+	}
+	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrapf(err, "unable to read from response")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, errors.New(fmt.Sprintf("got non 200 response from the server with %s ",
+			string(respBody)))
+	}
+	var outputJson map[string]interface{}
+	if err := json.Unmarshal(respBody, &outputJson); err != nil {
+		var errOutputJson map[string]interface{}
+		if err := json.Unmarshal(respBody, &errOutputJson); err == nil {
+			if _, ok := errOutputJson["errors"]; ok {
+				return nil, errors.Errorf("response error: %v", string(respBody))
+			}
+		}
+		return nil, errors.Wrapf(err, "unable to unmarshal the output to get JWTs")
+	}
+
+	data, found := outputJson["data"].(map[string]interface{})
+	if !found {
+		return nil, errors.Wrapf(err, "data entry found in the output")
+	}
+
+	l, found := data["login"].(map[string]interface{})
+	if !found {
+		return nil, errors.Wrapf(err, "data entry found in the output")
+	}
+
+	response, found := l["response"].(map[string]interface{})
+	if !found {
+		return nil, errors.Wrapf(err, "data entry found in the output")
+	}
+
+	newAccessJwt, found := response["accessJWT"].(string)
+	if !found || newAccessJwt == "" {
+		return nil, errors.Errorf("no access JWT found in the output")
+	}
+	newRefreshJwt, found := response["refreshJWT"].(string)
+	if !found || newRefreshJwt == "" {
+		return nil, errors.Errorf("no refresh JWT found in the output")
+	}
+
+	return &HttpToken{
+		UserId:       params.UserID,
+		Password:     params.Passwd,
+		AccessJwt:    newAccessJwt,
+		RefreshToken: newRefreshJwt,
+	}, nil
+}


### PR DESCRIPTION
We should not use dgraph binary in the tests. This PR fixes it and makes it use graphql API.
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgo/143)
<!-- Reviewable:end -->
