### PR TITLE
release: update dgo module from v200 to v210

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,14 @@ to understand how to run and work with Dgraph.
 Depending on the version of Dgraph that you are connecting to, you will have to
 use a different version of this client and their corresponding import paths.
 
-Dgraph version   | dgo version  |        dgo import path          |
----------------  | -----------  | ------------------------------- |
-  dgraph 1.0.X   |  dgo 1.X.Y   |   "github.com/dgraph-io/dgo"    |
-  dgraph 1.1.X   |  dgo 2.X.Y   | "github.com/dgraph-io/dgo/v2"   |
-  dgraph 20.03.0 |  dgo 200.03.0| "github.com/dgraph-io/dgo/v200" |
+Dgraph version   | dgo version   |        dgo import path          |
+---------------  | -----------   | ------------------------------- |
+  dgraph 1.0.X   |  dgo 1.X.Y    |   "github.com/dgraph-io/dgo"    |
+  dgraph 1.1.X   |  dgo 2.X.Y    | "github.com/dgraph-io/dgo/v2"   |
+  dgraph 20.03.0 |  dgo 200.03.0 | "github.com/dgraph-io/dgo/v200" |
+  dgraph 20.07.0 |  dgo 200.03.0 | "github.com/dgraph-io/dgo/v200" |
+  dgraph 20.11.0 |  dgo 200.03.0 | "github.com/dgraph-io/dgo/v200" |
+  dgraph 21.03.0 |  dgo 210.03.0 | "github.com/dgraph-io/dgo/v210" |
 
 Note: One of the most important API breakages from dgo v1 to v2 is in
 the function `dgo.Txn.Mutate`. This function returns an `*api.Assigned`
@@ -63,6 +66,27 @@ if err != nil {
 }
 defer conn.Close()
 dgraphClient := dgo.NewDgraphClient(api.NewDgraphClient(conn))
+```
+
+### Login into a namespace
+
+If your server has Access Control Lists enabled (Dgraph v1.1 or above), the client must be 
+logged in for accessing data. Use `Login` endpoint:
+
+Calling login will obtain and remember the access and refresh JWT tokens. All subsequent operations 
+via the logged in client will send along the stored access token.
+
+```go
+err := dgraphClient.Login(ctx, "user", "passwd")
+// Check error
+```
+
+If your server additionally has namespaces (Dgraph v21.03 or above), use the 
+`LoginIntoNamespace` API.
+
+```go
+err := dgraphClient.LoginIntoNamespace(ctx, "user", "passwd", 0x10)
+// Check error
 ```
 
 ### Altering the database

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ git push origin <new tag>
 
 2. Change all the import paths to import `v<new major version>`.
 
-For example, current import path is `"github.com/dgraph-io/dgo/v200"`.
+For example, if the current import path is `"github.com/dgraph-io/dgo/v200"`.
 When we release v201.07.0, we would replace the import paths to `"github.com/dgraph-io/dgo/v201"`.
 
 3. Update [Supported Version](https://github.com/dgraph-io/dgo/#supported-versions).

--- a/acl_test.go
+++ b/acl_test.go
@@ -24,8 +24,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v200"
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 )
 
 var (

--- a/client.go
+++ b/client.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
@@ -66,6 +66,8 @@ func NewDgraphClient(clients ...api.DgraphClient) *Dgraph {
 	return dg
 }
 
+// DialSlashEndpoint is deprecated and will be removed in v21.07 release. For more details,
+// see: https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
 // DialSlashEndpoint creates a new TLS connection to a Slash GraphQL or Slash Enterprise backend
 // It requires the backend endpoint as well as the api key
 func DialSlashEndpoint(endpoint, key string) (*grpc.ClientConn, error) {
@@ -90,6 +92,8 @@ func DialSlashEndpoint(endpoint, key string) (*grpc.ClientConn, error) {
 	)
 }
 
+// DialSlashGraphQLEndpoint is deprecated and will be removed in v21.07 release. For more details,
+// see: https://discuss.dgraph.io/t/regarding-slash-cloud-dgraph-endpoints-in-the-clients/13492
 // DialSlashGraphQLEndpoint is deprecated, as it leaks GRPC connections.
 // Please use DialSlashEndpoint instead
 func DialSlashGraphQLEndpoint(endpoint, key string) (*Dgraph, error) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v200"
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 )
 
 func TestTxnErrFinished(t *testing.T) {

--- a/example_get_schema_test.go
+++ b/example_get_schema_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 )
 
 func Example_getSchema() {

--- a/example_set_object_test.go
+++ b/example_set_object_test.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 )
 
 type School struct {

--- a/examples_test.go
+++ b/examples_test.go
@@ -24,8 +24,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgraph-io/dgo/v200"
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"google.golang.org/grpc"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dgraph-io/dgo/v200
+module github.com/dgraph-io/dgo/v210
 
 go 1.12
 

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 )
 
 // LoginParams stores the information needed to perform a login request.

--- a/txn.go
+++ b/txn.go
@@ -19,7 +19,7 @@ package dgo
 import (
 	"context"
 
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"

--- a/type_system_test.go
+++ b/type_system_test.go
@@ -22,8 +22,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v200"
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 
 	"github.com/stretchr/testify/require"
 )

--- a/upsert_test.go
+++ b/upsert_test.go
@@ -23,8 +23,8 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/dgraph-io/dgo/v200"
-	"github.com/dgraph-io/dgo/v200/protos/api"
+	"github.com/dgraph-io/dgo/v210"
+	"github.com/dgraph-io/dgo/v210/protos/api"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
Upgrades module path from `v200` to `v210`. 
Note that there is nothing BREAKING in this version. All the changes are backward compatible. We have added a few new APIs since `v200.03.0` release.
1. DialSlashEndpoint and few more related to auth/slash (these are deprecated and will be removed in later releases)
2. LoginIntoNamespace
3. Relogin
4. GetJwt

This PR additionally:
1. Updates the README with Login example.
2.  Add deprecation comment for DialSlash* APIs
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgo/148)
<!-- Reviewable:end -->
