### PR TITLE
fix(tests) check for nil token argument

### DIFF
--- a/testutil_test.go
+++ b/testutil_test.go
@@ -75,7 +75,7 @@ func MakeGQLRequestHelper(t *testing.T, endpoint string, params *GraphQLParams,
 	req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(b))
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "application/json")
-	if token.AccessJwt != "" {
+	if token != nil && token.AccessJwt != "" {
 		req.Header.Set("X-Dgraph-AccessToken", token.AccessJwt)
 	}
 	client := &http.Client{}


### PR DESCRIPTION
After run the tests I got Fail because the argument `token` of `MakeGQLRequestHelper` is nil:

![image](https://user-images.githubusercontent.com/12927166/136989496-69a39077-9e0b-4ecc-8b25-9e66196e432d.png)

This PR is just a small improvement by checking the token is not nil first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dgraph-io/dgo/152)
<!-- Reviewable:end -->
