### PR TITLE
chore(ci): need to export gopath

### DIFF
--- a/.github/workflows/ci-dgo-tests.yml
+++ b/.github/workflows/ci-dgo-tests.yml
@@ -48,6 +48,8 @@ jobs:
         run: |
           #!/bin/bash
           cd dgo
+          # go env settings
+          export GOPATH=~/go
           docker compose -f t/docker-compose.yml up -d
           echo "Waiting for cluster to be healthy..."
           sleep 20


### PR DESCRIPTION
Env variables are not seen inside the runner process; need to explicitly set gopath here.