### PR TITLE
chore(docs): correct namespace examples in README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # CODEOWNERS info: https://help.github.com/en/articles/about-code-owners
 # Owners are automatically requested for review for PRs that changes code
 # that they own.
-* @hypermodeinc/database
+* @hypermodeinc/maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # CODEOWNERS info: https://help.github.com/en/articles/about-code-owners
 # Owners are automatically requested for review for PRs that changes code
 # that they own.
-* @hypermodeinc/maintainers
+* @dgraph-io/maintainers

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ fmt.Printf("%s\n", resp.Json)
 Dgraph v25 supports creating namespaces using grpc API. You can create one using the dgo client.
 
 ```go
-_, err := client.CreateNamespace(context.TODO())
+nsID, err := client.CreateNamespace(context.TODO())
 // Handle error
 ```
 
@@ -306,7 +306,7 @@ _, err := client.CreateNamespace(context.TODO())
 To drop a namespace:
 
 ```go
-err := client.DropNamespace(context.TODO())
+err := client.DropNamespace(context.TODO(), nsID)
 // Handle error
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,18 +71,18 @@ Valid connection string args:
 
 | Arg         | Value                           | Description                                                                                                                                                   |
 | ----------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| apikey      | \<key\>                         | a Dgraph Cloud API Key                                                                                                                                        |
 | bearertoken | \<token\>                       | an access token                                                                                                                                               |
 | sslmode     | disable \| require \| verify-ca | TLS option, the default is `disable`. If `verify-ca` is set, the TLS certificate configured in the Dgraph cluster must be from a valid certificate authority. |
+| namespace   | \<namespace\>                   | a previously created integer-based namespace, username and password must be supplied                                                                          |
 
 Some example connection strings:
 
-| Value                                                                                                        | Explanation                                                                         |
-| ------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
-| dgraph://localhost:9080                                                                                      | Connect to localhost, no ACL, no TLS                                                |
-| dgraph://sally:supersecret@dg.example.com:443?sslmode=verify-ca                                              | Connect to remote server, use ACL and require TLS and a valid certificate from a CA |
-| dgraph://foo-bar.grpc.us-west-2.aws.cloud.dgraph.io:443?sslmode=verify-ca&apikey=\<your-api-connection-key\> | Connect to a Dgraph Cloud cluster                                                   |
-| dgraph://foo-bar.grpc.example.com?sslmode=verify-ca&bearertoken=\<some access token\>                        | Connect to a Dgraph cluster protected by a secure gateway                           |
+| Value                                                                                 | Explanation                                                                         |
+| ------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| dgraph://localhost:9080                                                               | Connect to localhost, no ACL, no TLS                                                |
+| dgraph://sally:supersecret@dg.example.com:443?sslmode=verify-ca                       | Connect to remote server, use ACL and require TLS and a valid certificate from a CA |
+| dgraph://foo-bar.grpc.example.com?sslmode=verify-ca&bearertoken=\<some access token\> | Connect to a Dgraph cluster protected by a secure gateway                           |
+| dgraph://sally:supersecret@dg.example.com:443?namespace=2                             | Connect to a ACL enabled Dgraph cluster in namespace 2                              |
 
 Using the `Open` function with a connection string:
 

--- a/client_test.go
+++ b/client_test.go
@@ -73,6 +73,9 @@ func TestOpen(t *testing.T) {
 	_, err = dgo.Open("dgraph://user:pass@localhost:9180")
 	require.ErrorContains(t, err, "invalid username or password")
 
+	_, err = dgo.Open("dgraph://localhost:9180?namespace=1")
+	require.ErrorContains(t, err, "invalid connection string: both username and password must be provided for namespace")
+
 	_, err = dgo.Open("dgraph://user:pass@localhost:9180?namespace=root")
 	require.ErrorContains(t, err, "invalid namespace ID: strconv.ParseUint: parsing \"root\": invalid syntax")
 

--- a/open.go
+++ b/open.go
@@ -135,8 +135,9 @@ func WithGrpcOption(opt grpc.DialOption) ClientOption {
 // For example `dgraph://localhost:9080?sslmode=require`
 //
 // Parameters:
-// - apikey: a Dgraph Cloud API key for authentication
-// - bearertoken: a token for bearer authentication
+// - apikey: a Dgraph Cloud API key for authentication (deprecated)
+// - bearertoken: a token for bearer authentication (deprecated)
+// - namespace: a previously created integer-based namespace ID, login credentials must be provided
 // - sslmode: SSL connection mode (options: disable, require, verify-ca)
 //   - disable: No TLS (default)
 //   - require: Use TLS but skip certificate verification
@@ -198,6 +199,9 @@ func Open(connStr string) (*Dgraph, error) {
 	}
 
 	if nsID != "" {
+		if u.User == nil {
+			return nil, errors.New("invalid connection string: both username and password must be provided for namespace")
+		}
 		nsID, err := strconv.ParseUint(nsID, 10, 64)
 		if err != nil {
 			return nil, fmt.Errorf("invalid namespace ID: %w", err)

--- a/protos/Makefile
+++ b/protos/Makefile
@@ -8,13 +8,25 @@ clean:
 	@rm -rf api && mkdir -p api
 	@rm -rf api.v2 && mkdir -p api.v2
 
+UNAME_S := $(shell uname -s)
+
 .PHONY: check
 check:
 	echo "Installing proto libraries to versions in go.mod." ; \
 		go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.36.0 ; \
 		go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.4.0
 
+ifneq ($(UNAME_S),Linux)
+.PHONY: regenerate
+regenerate:
+	@echo "Running in Docker..."
+	@docker run --rm -v $(shell pwd)/..:/go/src/github.com/dgraph-io/dgo \
+		-w /go/src/github.com/dgraph-io/dgo/protos \
+		golang:1.23.0 \
+		/bin/bash -c "apt-get update && apt-get install -y protobuf-compiler && make regenerate"
+else
 .PHONY: regenerate
 regenerate: check clean
 	@protoc --go_out=api --go-grpc_out=api --go_opt=paths=source_relative --go-grpc_opt=paths=source_relative api.proto
 	@echo Done.
+endif

--- a/protos/api/api.pb.go
+++ b/protos/api/api.pb.go
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: © Hypermode Inc. <hello@hypermode.com>
+// SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Style guide for Protocol Buffer 3.

--- a/protos/api/api_grpc.pb.go
+++ b/protos/api/api_grpc.pb.go
@@ -1,5 +1,5 @@
 //
-// SPDX-FileCopyrightText: © Hypermode Inc. <hello@hypermode.com>
+// SPDX-FileCopyrightText: © 2017-2025 Istari Digital, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
 // Style guide for Protocol Buffer 3.


### PR DESCRIPTION
**Description**

This PR corrects inaccuracies in the namespace examples in the README. There is also an added test to ensure proper enforcement of user credentials when using the namespace connection string parameter.

