### PR TITLE
add stale action

### DIFF
--- a/.github/workflows/ci-dgo-tests.yml
+++ b/.github/workflows/ci-dgo-tests.yml
@@ -34,7 +34,9 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version-file: dgo/go.mod
+          # Build target is dgraph, so install the Go version dgraph requires
+          # (dgo/go.mod can lag behind dgraph's required toolchain).
+          go-version-file: dgraph/go.mod
       - name: Make Linux Build and Docker Image
         run: cd dgraph && make docker-image
       - name: Move dgraph binary to gopath

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,13 @@
+name: Close stale issues and PRs
+on:
+  schedule:
+    - cron: 00 02 * * *
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    name: Stale
+    uses: dgraph-io/.github/.github/workflows/stale.yml@main

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -28,7 +28,7 @@ lint:
         - protos/api.v2/*.pb.go
   enabled:
     - golangci-lint2@2.4.0
-    - trivy@0.65.0
+    - trivy@0.71.2
     - renovate@41.93.2
     - actionlint@1.7.7
     - checkov@3.2.469


### PR DESCRIPTION
**Description**

This PR adds a scheduled stale-bot workflow (actions/stale@v9) that automatically marks inactive issues and pull requests as stale and closes them if they stay inactive.

How it works

Runs once a day at 02:00 UTC (cron schedule).
An issue or PR with no activity for 60 days is labeled Stale and a comment is posted.
After being marked stale, there is a 7-day cooling period: commenting (or any activity) removes the label and resets the timer; otherwise the item is closed automatically.


**Comment posted on stale items**

Issues
```
This issue has been stale for 60 days and will be closed automatically in 7 days. Comment to keep it open.
```

Pull requests

```
This PR has been stale for 60 days and will be closed automatically in 7 days. Comment to keep it open.
```